### PR TITLE
small refactors and formatting

### DIFF
--- a/src/csvparser.rs
+++ b/src/csvparser.rs
@@ -406,7 +406,7 @@ fn process_tax_consolidated_data(
 }
 /// Parse revolut CSV documents (savings account and trading)
 /// returns: (
-/// dividend transactions in a form: date, gross income , tax taken
+/// dividend transactions in a form: date, gross income, tax taken
 /// sold transactions in a form date acquired, date sold, cost basis, gross income
 /// )
 pub fn parse_revolut_transactions(
@@ -510,7 +510,7 @@ pub fn parse_revolut_transactions(
         log::info!("Filtered Sold Data of interest: {filtred_df}");
         acquired_dates = parse_investment_transaction_dates(&filtred_df, "Date acquired")?;
         sold_dates = parse_investment_transaction_dates(&filtred_df, "Date sold")?;
-        // For each sold data has to be one acquire date
+        // For each sold date there has to be one acquire date
         if acquired_dates.len() != sold_dates.len() {
             return Err("ERROR: Different number of acquired and sold dates".to_string());
         }

--- a/src/csvparser.rs
+++ b/src/csvparser.rs
@@ -227,20 +227,17 @@ fn parse_investment_transaction_dates(
 }
 
 fn parse_incomes(df: &DataFrame, col: &str) -> Result<Vec<crate::Currency>, String> {
-    let mut incomes: Vec<crate::Currency> = vec![];
     let moneyin = df
         .column(col)
         .map_err(|_| format!("Error: Unable to select Money In column '{}'", col))?;
     let possible_incomes = moneyin
         .utf8()
         .map_err(|_| format!("Error: Unable to convert column '{}' to utf8", col))?;
-    possible_incomes.into_iter().try_for_each(|x| {
-        if let Some(d) = x {
-            incomes.push(extract_cash(&d)?);
-        }
-        Ok::<(), String>(())
-    })?;
-    Ok(incomes)
+
+    possible_incomes.into_iter()
+    .filter_map(|x| x)
+    .map(|d| extract_cash(&d))
+    .collect()
 }
 
 fn parse_income_with_currency(

--- a/src/csvparser.rs
+++ b/src/csvparser.rs
@@ -64,15 +64,23 @@ fn extract_cash(cashline: &str) -> Result<crate::Currency, String> {
     let mut pln_parser = tuple((double::<&str, Error<_>>, tag("PLN")));
 
     if let Ok((_, (value, _))) = euro_parser(cashline_string.as_str()) {
-      return Ok(crate::Currency::EUR(value));
+        return Ok(crate::Currency::EUR(value));
     } else if let Ok((_, (value, _))) = pln_parser(cashline_string.as_str()) {
-      return Ok(crate::Currency::PLN(value));
+        return Ok(crate::Currency::PLN(value));
     } else if let Ok((_, (sign, _, value))) = usd_parser(cashline_string.as_str()) {
-      return Ok(crate::Currency::USD(if sign.len() == 1 { -value } else { value }));
+        return Ok(crate::Currency::USD(if sign.len() == 1 {
+            -value
+        } else {
+            value
+        }));
     } else if let Ok((_, (sign, value, _))) = usd_parser2(cashline_string.as_str()) {
-      return Ok(crate::Currency::USD(if sign.len() == 1 { -value } else { value }));
+        return Ok(crate::Currency::USD(if sign.len() == 1 {
+            -value
+        } else {
+            value
+        }));
     } else {
-      return Err(format!("Error converting: {cashline_string}"));
+        return Err(format!("Error converting: {cashline_string}"));
     }
 }
 
@@ -234,10 +242,11 @@ fn parse_incomes(df: &DataFrame, col: &str) -> Result<Vec<crate::Currency>, Stri
         .utf8()
         .map_err(|_| format!("Error: Unable to convert column '{}' to utf8", col))?;
 
-    possible_incomes.into_iter()
-    .filter_map(|x| x)
-    .map(|d| extract_cash(&d))
-    .collect()
+    possible_incomes
+        .into_iter()
+        .filter_map(|x| x)
+        .map(|d| extract_cash(&d))
+        .collect()
 }
 
 fn parse_income_with_currency(

--- a/src/pl.rs
+++ b/src/pl.rs
@@ -66,7 +66,7 @@ fn get_exchange_rates_from_cache(
             return Ok::<(), String>(());
         }
 
-        let (from, date) = match exchange {
+        let (_from, date) = match exchange {
             etradeTaxReturnHelper::Exchange::USD(date) => ("usd", date),
             etradeTaxReturnHelper::Exchange::EUR(date) => ("eur", date),
             etradeTaxReturnHelper::Exchange::PLN(_) => {

--- a/src/xlsxparser.rs
+++ b/src/xlsxparser.rs
@@ -101,7 +101,7 @@ mod tests {
     fn test_parse_gain_and_losses() -> Result<(), String> {
         assert_eq!(
             parse_gains_and_losses("data/G&L_Collapsed.xlsx"),
-            Ok((vec![
+            Ok(vec![
                 (
                     "04/24/2013".to_owned(),
                     "04/11/2022".to_owned(),
@@ -116,7 +116,7 @@ mod tests {
                     29.28195,
                     43.67
                 )
-            ]))
+            ])
         );
         assert_eq!(
             parse_gains_and_losses("data/G&L_Expanded.xlsx"),


### PR DESCRIPTION
I asked copilot if the match could be made cleaner and here is what is proposed.
It suggested that &'static str return type would just return a simple literal string instead of embedding `cashline_string` value into it so I changed return type to String.
I also asked for simplification of parse_incomes and I think it looks good.
