### PR TITLE
fix clippy detecting PI in exchange rate in nbp.rs

### DIFF
--- a/src/bin/gen_exchange_rates.rs
+++ b/src/bin/gen_exchange_rates.rs
@@ -81,6 +81,7 @@ fn main() {
     let mut output_content = String::new();
     output_content.push_str("use std::collections::HashMap;\n\n");
     output_content.push_str("use etradeTaxReturnHelper::Exchange;\n\n");
+    output_content.push_str("#[allow(clippy::approx_constant)]\n");
 
     output_content.push_str("pub fn get_exchange_rates() -> HashMap<Exchange, f64> {\n");
     output_content.push_str("   let mut exchange_rates = HashMap::new();\n");

--- a/src/nbp.rs
+++ b/src/nbp.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use etradeTaxReturnHelper::Exchange;
 
+#[allow(clippy::approx_constant)]
 pub fn get_exchange_rates() -> HashMap<Exchange, f64> {
     let mut exchange_rates = HashMap::new();
     exchange_rates.insert(Exchange::USD("2023-05-18".to_string()), 4.1929f64);


### PR DESCRIPTION
Adds attribute #[allow(clippy::approx_constant)] to generated function by gen_exchange_rates.rs.