### PR TITLE
RevolutTransactions struct and TransactionAccumulator

### DIFF
--- a/src/csvparser.rs
+++ b/src/csvparser.rs
@@ -26,8 +26,7 @@ struct TransactionAccumulator {
     pub taxes: Vec<crate::Currency>,
 }
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct RevolutTransactions {
     pub dividend_transactions: Vec<(String, crate::Currency, crate::Currency)>,
     pub sold_transactions: Vec<(String, String, crate::Currency, crate::Currency)>,
@@ -890,7 +889,7 @@ mod tests {
 
     #[test]
     fn test_parse_revolut_transactions_consolidated_eur() -> Result<(), String> {
-        let expected_result = Ok(RevolutTransactions{
+        let expected_result = Ok(RevolutTransactions {
             dividend_transactions: vec![
                 // EUR interests
                 (
@@ -921,7 +920,7 @@ mod tests {
 
     #[test]
     fn test_parse_revolut_transactions_consolidated() -> Result<(), String> {
-        let expected_result = Ok(RevolutTransactions{
+        let expected_result = Ok(RevolutTransactions {
             dividend_transactions: vec![
                 // EUR interests
                 (
@@ -1017,7 +1016,7 @@ mod tests {
 
     #[test]
     fn test_parse_revolut_investment_gain_and_losses_dividends() -> Result<(), String> {
-        let expected_result = Ok(RevolutTransactions{
+        let expected_result = Ok(RevolutTransactions {
             dividend_transactions: vec![
                 (
                     "06/04/24".to_owned(),
@@ -1054,7 +1053,7 @@ mod tests {
 
     #[test]
     fn test_parse_revolut_investment_with_commas_gain_and_losses_dividends() -> Result<(), String> {
-        let expected_result = Ok(RevolutTransactions{
+        let expected_result = Ok(RevolutTransactions {
             dividend_transactions: vec![
                 (
                     "06/04/24".to_owned(),
@@ -1116,7 +1115,7 @@ mod tests {
 
     #[test]
     fn test_parse_revolut_investment_gain_and_losses_sells_and_dividends() -> Result<(), String> {
-        let expected_result = Ok(RevolutTransactions{
+        let expected_result = Ok(RevolutTransactions {
             dividend_transactions: vec![
                 (
                     "03/04/24".to_owned(),
@@ -1220,7 +1219,7 @@ mod tests {
 
     #[test]
     fn test_parse_revolut_transactions_english_statement_pln() -> Result<(), String> {
-        let expected_result = Ok(RevolutTransactions{
+        let expected_result = Ok(RevolutTransactions {
             dividend_transactions: vec![
                 (
                     "12/12/23".to_owned(),
@@ -1331,7 +1330,7 @@ mod tests {
 
     #[test]
     fn test_parse_revolut_investment_transactions_usd() -> Result<(), String> {
-        let expected_result = Ok(RevolutTransactions{
+        let expected_result = Ok(RevolutTransactions {
             dividend_transactions: vec![
                 (
                     "11/02/23".to_owned(),

--- a/src/csvparser.rs
+++ b/src/csvparser.rs
@@ -633,7 +633,7 @@ pub fn parse_revolut_transactions(csvtoparse: &str) -> Result<RevolutTransaction
     Ok(RevolutTransactions {
         dividend_transactions,
         sold_transactions,
-        crypto_transactions: crypto_transactions,
+        crypto_transactions,
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,9 +387,13 @@ pub fn run_taxation(
         } else if x.contains(".xlsx") {
             parsed_gain_and_losses.append(&mut xlsxparser::parse_gains_and_losses(x)?);
         } else if x.contains(".csv") {
-            let (mut div_t, mut sold_t) = csvparser::parse_revolut_transactions(x)?;
-            parsed_revolut_dividends_transactions.append(&mut div_t);
-            parsed_revolut_sold_transactions.append(&mut sold_t);
+            let csvparser::RevolutTransactions {
+                mut dividend_transactions,
+                mut sold_transactions,
+                ..
+            } = csvparser::parse_revolut_transactions(x)?;
+            parsed_revolut_dividends_transactions.append(&mut dividend_transactions);
+            parsed_revolut_sold_transactions.append(&mut sold_transactions);
         } else {
             return Err(format!("Error: Unable to open a file: {x}"));
         }


### PR DESCRIPTION
Keep logic unchanged
Create TransactionAccumulator struct to group commonly used together 7 vectors
Create RevolutTransactions struct instead of a tuple to name returned fields from  parse_revolut_transactions
add empty crypto_transactions field

Next, I will separate crypto into crypto_transactions

@jczaja please share your thoughts before I continue